### PR TITLE
Aceto 1.9 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ depends on the previous command.
   interpreter abruptly.
 - ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `x`: Pop a value and
   ignore it.
+- ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `ø`: Empty the
+  current stack.
 
 ### Movement, Conditions, and Catching
 - ![#1589F0](https://placehold.it/15/1589F0/000000?text=+) `<`, `>`, `v`, `^`:
@@ -129,6 +131,8 @@ depends on the previous command.
   end (the bottom right cell, or 0,0, if the direction is reversed).
 - ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `j`: Pop a value and
   jump so many positions ahead. Also works with negative numbers.
+- ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `§`: Pop a value and
+  jump to the absolute position of that value.
 - ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `` ` ``: Pops a
   value: If it's truthy, behaves like a space (nop), if not, like a backslash
   (escape).
@@ -177,6 +181,8 @@ depends on the previous command.
   `»`).
 - ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) `F`: Raise the second
   popped number by the power of the first.
+- ![#1589F0](https://placehold.it/15/1589F0/000000?text=+) `±`: Push the
+  absolute value of a popped value.
 
 ### Literals
 - ![#c5f015](https://placehold.it/15/c5f015/000000?text=+) `0`, `1`, `2`, ...,
@@ -256,6 +262,8 @@ depends on the previous command.
   timestamp to now. It is initialized to the time of script start.
 - ![#c5f015](https://placehold.it/15/c5f015/000000?text=+) `t`: Push the
   difference between now and the global timestamp.
+- ![#c5f015](https://placehold.it/15/c5f015/000000?text=+) `™`: Push a local,
+  datetime on the stack (year, month, day, hour, minute, second).
 - ![#1589F0](https://placehold.it/15/1589F0/000000?text=+) `C`: Pop a value and
   push a boolean: Whether the value is contained in the current stack.
 - ![#c5f015](https://placehold.it/15/c5f015/000000?text=+) `l`: Push the length

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aceto
 
-Aceto is a simple stack language that is based on a 2D Hilbert curve grid. The
+Aceto ([aˈtʃeto]) is a simple stack language that is based on a 2D Hilbert curve grid. The
 name is a reference to Aceto Balsamico (balsamic vinegar), and to
 [OIL](https://github.com/L3viathan/OIL). It was a birthday present for
 [@sarnthil](https://github.com/sarnthil).

--- a/aceto.py
+++ b/aceto.py
@@ -560,6 +560,10 @@ class Aceto(object):
         method = self.commands.get(self.previous_cmd, Aceto._nop)
         method(self, self.previous_cmd)
 
+    def _empty_stack(self, cmd) -> 'ø':
+        self.stack[self.sid] = []
+        self.move()
+
     def _jump(self, cmd) -> 'j':
         steps = self.pop()
         distance = hilbert.distance_from_coordinates([self.y,self.x], self.p, N=2)

--- a/aceto.py
+++ b/aceto.py
@@ -18,6 +18,7 @@ import tty
 import termios
 import time
 import shutil
+import re
 from math import ceil, log2
 from numbers import Number
 from collections import defaultdict

--- a/aceto.py
+++ b/aceto.py
@@ -325,7 +325,7 @@ class Aceto(object):
         self.push(y)
         self.move()
 
-    def _int(self, cmd) -> 'i':
+    def _cast_int(self, cmd) -> 'i':
         x = self.pop()
         try:
             self.push(int(x))
@@ -333,7 +333,7 @@ class Aceto(object):
             raise CodeException(f"Can't cast {x!r} to int")
         self.move()
 
-    def _bool(self, cmd) -> 'b':
+    def _cast_bool(self, cmd) -> 'b':
         x = self.pop()
         try:
             self.push(bool(x))
@@ -341,7 +341,7 @@ class Aceto(object):
             raise CodeException(f"Can't cast {x!r} to bool")
         self.move()
 
-    def _string(self, cmd) -> '∑':
+    def _cast_string(self, cmd) -> '∑':
         x = self.pop()
         try:
             self.push(str(x))
@@ -381,7 +381,7 @@ class Aceto(object):
             self.push(0)
         self.move()
 
-    def _float(self, cmd) -> 'f':
+    def _cast_float(self, cmd) -> 'f':
         x = self.pop()
         try:
             self.push(float(x))
@@ -566,6 +566,12 @@ class Aceto(object):
         y, x = hilbert.coordinates_from_distance(distance+self.dir*steps, self.p, N=2)
         self.x, self.y = x, y
 
+    def _goto(self, cmd) -> '§':
+        distance = self.pop()
+        #TODO: should take the direction (self.dir) into account.
+        y, x = hilbert.coordinates_from_distance(distance, self.p, N=2)
+        self.x, self.y = x, y
+
     def _join(self, cmd) -> 'J':
         x, y = self.pop(), self.pop()
         self.push(str(x) + str(y))
@@ -584,12 +590,16 @@ class Aceto(object):
         else:
             self.move()
 
-    def _get_time(self, cmd) -> 't':
+    def _get_stopwatch(self, cmd) -> 't':
         self.push(time.time()-self.timestamp)
         self.move()
 
-    def _set_time(self, cmd) -> 'T':
+    def _set_stopwatch(self, cmd) -> 'T':
         self.timestamp = time.time()
+        self.move()
+
+    def _get_datetime(self, cmd) -> '™':
+        self.pushiter([*time.localtime()][:6][::-1])
         self.move()
 
     def _drop(self, cmd) -> 'x':
@@ -706,10 +716,16 @@ class Aceto(object):
         x = self.pop()
         y = self.pop()
         self.push(y>>x)
+        self.move()
 
     def _multiply_stack(self, cmd) -> '×':
         x = self.pop()
         self.stacks[self.sid] *= x
+        self.move()
+
+    def _abs(self, cmd) -> '±':
+        x = self.pop()
+        self.push(abs(x))
         self.move()
 
     def _explode_string(self, cmd) -> '€':
@@ -747,13 +763,20 @@ if __name__ == '__main__':
     if not args['<filename>']:
         cols, _ = shutil.get_terminal_size((80, 20))
         info = [f'{c} {f.__name__[1:]}' for c, f in A.commands.items()]
+        info.sort()
         maxlen = max(len(x) for x in info) + 1
         columns = cols // maxlen
         iinfo = iter(info)
+        end_character = '' if sys.stdout.isatty() else '\n'
         try:
             while True:
                 for _ in range(columns):
-                    print(next(iinfo).ljust(maxlen), end='')
-                print()
+                    item = next(iinfo)
+                    # skip all numbers except for 0
+                    while any(item.startswith(x) for x in "123456789"):
+                        item = next(iinfo)
+                    print(item.ljust(maxlen), end=end_character)
+                if not end_character:
+                    print()
         except StopIteration:
             print()


### PR DESCRIPTION
- New commands: `±™ø§`
- Fixes for regex and bitwise shifts
- Nicer default output (tty aware)